### PR TITLE
Feature: Operator connection

### DIFF
--- a/chat/chat.go
+++ b/chat/chat.go
@@ -4,33 +4,37 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/wayn3h0/go-uuid" // UUID (RFC 4122)
+	// "github.com/wayn3h0/go-uuid" // UUID (RFC 4122)
 
 	"github.com/minimalchat/daemon/client"
-	"github.com/minimalchat/daemon/operator"
+	// "github.com/minimalchat/daemon/operator"
 	// "github.com/minimalchat/daemon/person"
 )
 
 /*
 Chat struct defines communication session */
 type Chat struct {
-	UID          string             `json:"id"`
-	Client       *client.Client     `json:"client"`
-	Operator     *operator.Operator `json:"operator"`
-	CreationTime time.Time          `json:"creation_time"`
-	UpdatedTime  time.Time          `json:"update_time"`
-	Open         bool               `json:"open"`
+	UID    string         `json:"id"`
+	Client *client.Client `json:"client"`
+	// TODO: Turn Operator into array of Operators
+	// Operator     *operator.Operator `json:"operator"`
+	CreationTime time.Time `json:"creation_time"`
+	UpdatedTime  time.Time `json:"update_time"`
+	Open         bool      `json:"open"`
 }
 
 /*
 Create builds a new `Chat` session*/
-func Create(chat Chat) *Chat {
-	if chat.UID == "" {
-		uuid, _ := uuid.NewRandom()
-		chat.UID = uuid.String()
+func Create(cl *client.Client) *Chat {
+	c := Chat{
+		UID:          cl.UID,
+		Client:       cl,
+		CreationTime: time.Now(),
+		UpdatedTime:  time.Now(),
+		Open:         true,
 	}
 
-	return &chat
+	return &c
 }
 
 func (c *Chat) String() string {

--- a/chat/router.go
+++ b/chat/router.go
@@ -193,7 +193,7 @@ func createMessage(ds *store.InMemory) func(resp http.ResponseWriter, req *http.
 		}
 
 		if ch, ok := result.(Chat); ok {
-			log.Println(DEBUG, "api/operator:", msg.Content)
+			log.Println(DEBUG, "api/operator:", msg.Content, ch.UID)
 
 			// Fix if missing in Message object
 			if msg.Chat == "" {
@@ -202,7 +202,8 @@ func createMessage(ds *store.InMemory) func(resp http.ResponseWriter, req *http.
 
 			ds.Put(msg)
 
-			ch.Client.Socket.Emit("operator:message", msg.Content, nil)
+			// TODO: Pass API post message to Operator via socket somehow
+			// ch.Client.Socket.Emit("operator:message", msg.Content, nil)
 		} else {
 			log.Println(ERROR, "api/message:", "Could not cast store data to struct", ok, result.(Chat))
 			resp.WriteHeader(http.StatusInternalServerError)

--- a/client/client.go
+++ b/client/client.go
@@ -2,31 +2,51 @@ package client
 
 import (
 	"fmt"
+	"log"
 
-	// "github.com/wayn3h0/go-uuid" // UUID (RFC 4122)
-	"github.com/googollee/go-socket.io" // Socket
+	"github.com/wayn3h0/go-uuid" // UUID (RFC 4122)
+	// "github.com/googollee/go-socket.io" // Socket
 
 	"github.com/minimalchat/daemon/person"
+)
+
+const (
+	DEBUG   string = "DEBUG"
+	INFO    string = "INFO"
+	WARNING string = "WARN"
+	ERROR   string = "ERROR"
+	FATAL   string = "FATAL"
 )
 
 /*
 Client struct defines a web visitor */
 type Client struct {
 	person.Person
-	Name   string          `json:"name"`
-	UID    string          `json:"id"`
-	Socket socketio.Socket `json:"socket"`
+	Name string `json:"name"`
+	UID  string `json:"id"`
+	// Socket socketio.Socket `json:"socket"`
 }
 
 /*
 Create builds a new `Client` */
-func Create(c Client, sock socketio.Socket) *Client {
-	if c.UID == "" {
-		// uuid, _ := uuid.NewRandom()
-		c.UID = sock.Id()
+func Create(id string) *Client {
+	c := Client{
+		Person: person.Person{
+			FirstName: "Site",
+			LastName:  "Visitor",
+		},
+		Name: "Site Visitor",
 	}
 
-	c.Socket = sock
+	if id == "" {
+		log.Println(WARNING, "No client ID specified")
+
+		uuid, _ := uuid.NewRandom()
+
+		c.UID = uuid.String()
+	} else {
+		c.UID = id
+	}
 
 	return &c
 }

--- a/client/router.go
+++ b/client/router.go
@@ -12,13 +12,13 @@ import (
 )
 
 // Log levels
-const (
-	DEBUG   string = "DEBUG"
-	INFO    string = "INFO"
-	WARNING string = "WARN"
-	ERROR   string = "ERROR"
-	FATAL   string = "FATAL"
-)
+//const (
+//	DEBUG   string = "DEBUG"
+//	INFO    string = "INFO"
+//	WARNING string = "WARN"
+//	ERROR   string = "ERROR"
+//	FATAL   string = "FATAL"
+//)
 
 /*
 Routes defines the Client API routes  */

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -3,8 +3,8 @@ package operator
 import (
 	"fmt"
 
-	// "github.com/wayn3h0/go-uuid" // UUID (RFC 4122)
-	"github.com/googollee/go-socket.io" // Socket
+	"github.com/wayn3h0/go-uuid" // UUID (RFC 4122)
+	// "github.com/googollee/go-socket.io" // Socket
 
 	"github.com/minimalchat/daemon/person"
 )
@@ -13,20 +13,24 @@ import (
 Operator struct defines a site owner */
 type Operator struct {
 	person.Person
-	UserName string          `json:"username"`
-	UID      string          `json:"id"`
-	Socket   socketio.Socket `json:"socket"`
+	UserName string `json:"username"`
+	UID      string `json:"id"`
+	// Socket   socketio.Socket `json:"socket"`
 }
 
 /*
 Create builds a new `Operator` */
-func Create(o Operator, sock socketio.Socket) *Operator {
-	if o.UID == "" {
-		// uuid, _ := uuid.NewRandom()
-		o.UID = sock.Id()
+func Create(id string) *Operator {
+	o := Operator{
+		UserName: "steve",
 	}
 
-	o.Socket = sock
+	if id == "" {
+		uuid, _ := uuid.NewRandom()
+		o.UID = uuid.String()
+	} else {
+		o.UID = id
+	}
 
 	return &o
 }

--- a/server/socket/server.go
+++ b/server/socket/server.go
@@ -13,7 +13,7 @@ import (
 	"github.com/minimalchat/daemon/chat"
 	"github.com/minimalchat/daemon/client"
 	"github.com/minimalchat/daemon/operator"
-	"github.com/minimalchat/daemon/person"
+	// "github.com/minimalchat/daemon/person"
 	"github.com/minimalchat/daemon/store" // InMemory store
 )
 
@@ -30,10 +30,11 @@ const (
 Server is the socket.io abstraction for Minimal Chat */
 type Server struct {
 	// TODO: Poor data structure, should thing of something smarter?
-	Operators map[string]*operator.Operator
-	Clients   map[string]*client.Client
-	Chats     map[string]*chat.Chat
-	Server    *socketio.Server
+	//  We need to store the active sockets rather than specific application
+	//  data.
+	Sockets map[string]socketio.Socket
+	store   *store.InMemory
+	server  *socketio.Server
 }
 
 /*
@@ -42,12 +43,15 @@ connections. */
 func Listen(ds *store.InMemory) (*Server, error) {
 	log.Println(DEBUG, "socket:", "Starting WebSocket server ...")
 
+	ping, _ := time.ParseDuration("5s")
+
 	srv, err := socketio.NewServer(nil)
+	srv.SetPingInterval(ping)
+
 	sck := Server{
-		Operators: make(map[string]*operator.Operator),
-		Clients:   make(map[string]*client.Client),
-		Chats:     make(map[string]*chat.Chat),
-		Server:    srv,
+		Sockets: make(map[string]socketio.Socket),
+		store:   ds,
+		server:  srv,
 	}
 
 	// TODO: Return an error instead
@@ -55,7 +59,7 @@ func Listen(ds *store.InMemory) (*Server, error) {
 		return nil, err
 	}
 
-	srv.On("connection", sck.onConnection(ds))
+	srv.On("connection", sck.onConnect)
 	srv.On("error", sck.onError)
 
 	return &sck, nil
@@ -64,163 +68,157 @@ func Listen(ds *store.InMemory) (*Server, error) {
 /*
 ServeHTTP serves the socket.io client script */
 func (s Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	s.Server.ServeHTTP(w, r)
+	s.server.ServeHTTP(w, r)
 }
 
 func (s Server) emitToOperators(event string, data string) {
-	// if (event == nil) {
-	//   log.Println(WARNING, "Unknown event to emit")
-	//   return
-	// }
+	ops, _ := s.store.Search("operator.")
 
-	// Update Operators of the new messages
-	for _, op := range s.Operators {
-		log.Println(DEBUG, "socket:", fmt.Sprintf("Sending %s \"%s\" to %s", event, data, op.Socket.Id()))
+	if len(ops) == 0 {
+		log.Println(INFO, "socket:", fmt.Sprintf("No operators online (%d records)", len(ops)))
+		return
+	}
 
-		op.Socket.Emit(event, data, nil)
+	log.Println(INFO, "socket:", fmt.Sprintf("Sending '%s' message (%d operators)", event, len(ops)))
+
+	for _, op := range ops {
+		o := op.(*operator.Operator)
+		osck := s.Sockets[o.UID]
+
+		log.Println(DEBUG, "socket:", fmt.Sprintf("Sent %s \"%s\" to %s", event, data, osck.Id()))
+
+		osck.Emit(event, data, nil)
 	}
 }
 
-func (s Server) onOperatorConnection(ds *store.InMemory, sock socketio.Socket) {
+func (s Server) onOperatorConnection(sock socketio.Socket) {
+	// TODO: Operator should be created via API before a connection can
+	//  be made
 	// Create Operator
-	// TODO: Pull Operator from DB if we already know them
-	s.Operators[sock.Id()] = operator.Create(
-		operator.Operator{
-			// FirstName: "Operator",
-			// LastName: "Steve",
-			UserName: "steve",
-		},
-		sock,
-	)
+	op := operator.Create(sock.Id())
 
-	// Save Operator to DB
-	ds.Put(*s.Operators[sock.Id()])
-
+	// Save Operator to datastore
+	s.store.Put(op)
 }
 
-func (s Server) onClientConnection(ds *store.InMemory, sock socketio.Socket) {
-	// Create Client
-	// TODO: See if we can "recall" if this is a returning client?
-	s.Clients[sock.Id()] = client.Create(
-		client.Client{
-			Person: person.Person{
-				FirstName: "Site",
-				LastName:  "Visitor",
-			},
-			Name: "Site Visitor",
-		},
-		sock,
-	)
+func (s Server) onClientConnection(sock socketio.Socket) {
+	// TODO: Try to recover previous Client/Chat
 
-	// Save Client to DB
-	ds.Put(*s.Clients[sock.Id()])
+	// Create Client
+	cl := client.Create(sock.Id())
+
+	// Save Client to datastore
+	s.store.Put(cl)
 
 	// Create Chat
-	// TODO: See if we can "recall" the returning chat?
-	s.Chats[sock.Id()] = chat.Create(chat.Chat{
-		Client:       s.Clients[sock.Id()],
-		Operator:     nil,
-		Open:         true,
-		CreationTime: time.Now(),
-		UpdatedTime:  time.Now(),
-	})
+	ch := chat.Create(cl)
 
-	// Save Chat to DB
-	ds.Put(*s.Chats[sock.Id()])
+	// Save Chat to datastore
+	s.store.Put(ch)
 
-	jsonChat, _ := json.Marshal(s.Chats[sock.Id()])
+	// Convert to JSON object
+	jsonChat, _ := json.Marshal(ch)
 	var buffer bytes.Buffer
 	buffer.Write(jsonChat)
 	buffer.WriteString("\n")
 
-	// Emit to Operators
+	// Emit chat:new to Operators
 	s.emitToOperators("chat:new", buffer.String())
 
+	// Emit chat:new to self
+	sock.Emit("chat:new", buffer.String())
 }
 
-func (s Server) onConnection(ds *store.InMemory) func(sock socketio.Socket) {
-	return func(sock socketio.Socket) {
-		log.Println(INFO, "socket:", fmt.Sprintf("Incoming %s connection %s", sock.Request().URL.Query().Get("type"), sock.Id()))
+func (s Server) onConnect(sock socketio.Socket) {
 
-		t := sock.Request().URL.Query().Get("type")
+	// Get type GET parameter
+	t := sock.Request().URL.Query().Get("type")
 
-		// TODO: Verify that the socket connection is real
+	log.Println(INFO, "socket:", fmt.Sprintf("Incoming %s connection %s", t, sock.Id()))
+
+	// TODO: Verify that the socket connection is real
+	if t == "operator" {
+
+		s.onOperatorConnection(sock)
+
+	} else if t == "client" {
+
+		s.onClientConnection(sock)
+	} else {
+		// TODO: Write some proper error handling here, do we close the connection?
+		log.Println(ERROR, "socket:", "Unknown chat type specified")
+	}
+
+	// Save Socket to use later
+	s.Sockets[sock.Id()] = sock
+
+	sock.On("client:message", s.onClientMessage(sock))
+	sock.On("operator:message", s.onOperatorMessage(sock))
+
+	sock.On("disconnection", func() {
+		log.Println(DEBUG, "socket:", fmt.Sprintf("%s disconnected", sock.Id()))
+
+		// TODO: Save chat?
+
 		if t == "operator" {
-
-			s.onOperatorConnection(ds, sock)
-
+			// delete(s.Operators, sock.Id())
 		} else if t == "client" {
-
-			s.onClientConnection(ds, sock)
-
-		} else {
-
-			// TODO: Write some proper error handling here, do we close the connection?
-			log.Println(ERROR, "socket:", "Unknown chat type specified")
+			// delete(s.Clients, sock.Id())
 		}
 
-		sock.On("client:message", s.onClientMessage(ds, sock))
-		sock.On("operator:message", s.onOperatorMessage(ds, sock))
+		delete(s.Sockets, sock.Id())
+	})
 
-		// Disconnection event
-		sock.On("disconnection", func() {
-			log.Println(DEBUG, "socket:", fmt.Sprintf("%s disconnected", sock.Id()))
-
-			// TODO: Save chat?
-
-			if t == "operator" {
-
-				delete(s.Operators, sock.Id())
-			} else if t == "client" {
-
-				delete(s.Clients, sock.Id())
-			}
-		})
-	}
 }
 
-func (s Server) onClientMessage(ds *store.InMemory, sock socketio.Socket) func(msg string) {
+func (s Server) onClientMessage(sock socketio.Socket) func(string) {
 	return func(msg string) {
 
 		log.Println(DEBUG, "client", fmt.Sprintf("%s: %s", sock.Id(), msg))
 
-		// Create Message
-		m := chat.Message{
-			Timestamp: time.Now(),
-			Content:   msg,
-			Author:    s.Clients[sock.Id()].StoreKey(),
-			Chat:      s.Chats[sock.Id()].UID,
-		}
+		var m chat.Message
 
-		// Save Message to DB
-		ds.Put(m)
-
-		jsonMessage, _ := json.Marshal(m)
-		var buffer bytes.Buffer
-		buffer.Write(jsonMessage)
-		buffer.WriteString("\n")
-
-		// Update Operators of the new messages
-		s.emitToOperators("client:message", buffer.String())
-	}
-}
-
-func (s Server) onOperatorMessage(ds *store.InMemory, sock socketio.Socket) func(msg string) {
-	return func(msg string) {
-		// TODO: Get chat from message, and then update it/send to correct client
-
-		log.Println(DEBUG, "operator", fmt.Sprintf("%s: %s", sock.Id(), msg))
+		// String to JSON
+		json.Unmarshal([]byte(msg), &m)
 
 		// Create Message
 		// m := chat.Message{
-		//   Timestamp: time.Now(),
-		//   Content: msg,
-		//   Author: this.Operators[sock.Id()].StoreKey(),
-		//   Chat: ch.ID,
+		// 	Timestamp: time.Now(),
+		// 	Content:   msg,
+		// 	// TODO: This duplication seems unecessary?
+		// 	Author: sock.Id(),
+		// 	Chat:   sock.Id(),
 		// }
 
-		// Save Message to DB
-		// ds.Put(m)
+		// Save Message to datastore
+		s.store.Put(m)
+
+		// jsonMessage, _ := json.Marshal(m)
+		// var buffer bytes.Buffer
+		// buffer.Write(jsonMessage)
+		// buffer.WriteString("\n")
+
+		// Update Operators of the new messages
+		s.emitToOperators("client:message", msg)
+	}
+}
+
+func (s Server) onOperatorMessage(sock socketio.Socket) func(string) {
+	return func(msg string) {
+
+		log.Println(DEBUG, "operator", fmt.Sprintf("%s: %s", sock.Id(), msg))
+
+		var m chat.Message
+
+		// String to JSON
+		json.Unmarshal([]byte(msg), &m)
+
+		// Save Message to datastore
+		s.store.Put(m)
+
+		// Update Client with new message
+		clsck := s.Sockets[m.Chat]
+		clsck.Emit("operator:message", msg, nil)
 	}
 }
 


### PR DESCRIPTION
Bi-directional communication between client and operator.

Lost the ability to send messages via API due to needing to refactor how socket connections are saved on the daemon. Before, we would save the socket connection on the client or operator objects, this poses some problems with reuse, as well as includes an unnecessary socket key on API response. For now I'll leave out the ability to post messages via API to a client (from an operator) with a 405 or 501.

- Refactored how Client, Operator and Chat's are created
- Refactored Client, Operator, and Chat structs
- Now only saving sockets in a key (socket ID) / value (actual socket) array on the socket server object
- Added `chat:new` message and emits it to both operators and client that joined (to pass back the socket ID)
- Added `operator:message` functionality
