### PR TITLE
Feature, Typing++

### DIFF
--- a/chat/message.go
+++ b/chat/message.go
@@ -3,9 +3,32 @@ package chat
 import (
 	"bytes"
 	"fmt"
+	"time"
 
 	"github.com/golang/protobuf/jsonpb"
+	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 )
+
+/*
+Create constructs a new `Message` with a default timestamp of now */
+func CreateMessage() *Message {
+	now := time.Now()
+
+	// Get the unix timestamp (seconds since epoch)
+	seconds := now.Unix()
+	nanos := int32(now.Sub(time.Unix(seconds, 0)))
+
+	ts := &timestamp.Timestamp{
+		Seconds: seconds,
+		Nanos:   nanos,
+	}
+
+	m := Message{
+		Timestamp: ts,
+	}
+
+	return &m
+}
 
 func (m *Message) UnmarshalJSON(data []byte) error {
 	u := jsonpb.Unmarshaler{}

--- a/chat/message.go
+++ b/chat/message.go
@@ -10,7 +10,7 @@ import (
 )
 
 /*
-Create constructs a new `Message` with a default timestamp of now */
+CreateMessage constructs a new `Message` with a default timestamp of now */
 func CreateMessage() *Message {
 	now := time.Now()
 

--- a/server/socket/client.go
+++ b/server/socket/client.go
@@ -123,22 +123,17 @@ func (s Socket) onClientMessage(data string) {
 	}
 }
 
-func (s Socket) onClientTyping() {
-	// Create message to pass so the operator knows who is typing
-	msg := chat.CreateMessage()
-	msg.Content = ""
-	msg.Author = s.conn.Id()
-	msg.Chat = s.conn.Id()
+func (s Socket) onClientTyping(data string) {
+	// Create message from JSON
+	var msg chat.Message
 
-	msgJson, _ := json.Marshal(msg)
-	var buffer bytes.Buffer
-	buffer.Write(msgJson)
+	json.Unmarshal([]byte(data), &msg)
 
 	log.Println(DEBUG, "client", fmt.Sprintf("%s: typing ...", s.conn.Id()))
 
 	s.server.broadcastToOperators <- &SocketMessage{
 		event:   "client:typing",
-		message: buffer.String(),
+		message: data,
 		target:  "",
 	}
 }
@@ -170,6 +165,21 @@ func (s Socket) onOperatorMessage(data string) {
 
 	s.server.broadcastToClient <- &SocketMessage{
 		event:   "operator:message",
+		message: data,
+		target:  msg.Chat,
+	}
+}
+
+func (s Socket) onOperatorTyping(data string) {
+	// Create message from JSON
+	var msg chat.Message
+
+	json.Unmarshal([]byte(data), &msg)
+
+	log.Println(DEBUG, "operator", fmt.Sprintf("%s: typing ...", s.conn.Id()))
+
+	s.server.broadcastToClient <- &SocketMessage{
+		event:   "operator:typing",
 		message: data,
 		target:  msg.Chat,
 	}

--- a/server/socket/server.go
+++ b/server/socket/server.go
@@ -156,11 +156,15 @@ func (s *Server) onConnect(c socketio.Socket) {
 	})
 
 	sock.conn.On("client:typing", func(data string) {
-		go sock.onClientTyping()
+		go sock.onClientTyping(data)
 	})
 
 	sock.conn.On("operator:message", func(data string) {
 		go sock.onOperatorMessage(data)
+	})
+
+	sock.conn.On("operator:typing", func(data string) {
+		go sock.onOperatorTyping(data)
 	})
 
 	sock.conn.On("disconnection", func() {

--- a/server/socket/server.go
+++ b/server/socket/server.go
@@ -155,6 +155,10 @@ func (s *Server) onConnect(c socketio.Socket) {
 		go sock.onClientMessage(data)
 	})
 
+	sock.conn.On("client:typing", func(data string) {
+		go sock.onClientTyping()
+	})
+
 	sock.conn.On("operator:message", func(data string) {
 		go sock.onOperatorMessage(data)
 	})


### PR DESCRIPTION
This finishes off #21. It enables both the [client](https://github.com/minimalchat/client/pull/34), and the [operator](https://github.com/minimalchat/operator-app/pull/62) PRs for the same thing.

No gif for this one,

Technical Stuff:
- Reuses the broadcastToOperators and broadcastToClient channels
- Basically just passes the message through, doesnt save the message.