### PR TITLE
Fixing CORS issue to allow for multiple cors origins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM ubuntu:xenial
+FROM ubuntu:xenial-20190515
 
 RUN mkdir -p /daemon
 WORKDIR /daemon
 
+RUN apt clean && cat /etc/apt/sources.list
 RUN apt update
 RUN apt install -y golang ca-certificates
 

--- a/main.go
+++ b/main.go
@@ -37,11 +37,11 @@ func init() {
 	// Configuration
 	flag.StringVar(&config.Host, "host", os.Getenv("HOST"), "IP to serve http and websocket traffic on")
 	flag.StringVar(&config.Port, "port", os.Getenv("PORT"), "Port used to serve HTTP and websocket traffic on")
-	flag.StringVar(&config.Id, "id", "", "A string used to identify the server in outbound HTTP requests")
+	flag.StringVar(&config.ID, "id", "", "A string used to identify the server in outbound HTTP requests")
 	flag.StringVar(&config.SSLCertFile, "ssl-cert", "", "SSL Certificate Filepath")
 	flag.StringVar(&config.SSLKeyFile, "ssl-key", "", "SSL Key Filepath")
 	flag.IntVar(&config.SSLPort, "ssl-port", 4443, "Port used to serve SSL HTTPS and websocket traffic on")
-	flag.StringVar(&config.CORSOrigin, "cors-origin", "http://localhost:3000", "Host to allow cross origin resource sharing (CORS)")
+	flag.StringVar(&config.CORSOrigins, "cors-origins", "http://localhost:3000", "Comma separated Hosts to allow cross origin resource sharing (CORS)")
 	flag.BoolVar(&config.CORSEnabled, "cors", false, "Set if the daemon will handle CORS")
 	flag.BoolVar(&needHelp, "h", false, "Get help")
 }

--- a/pkg/server/socket/client.go
+++ b/pkg/server/socket/client.go
@@ -92,7 +92,7 @@ func (c Conn) runWebhooks(e []string, d []byte) {
 			for j := 0; j < len(w); j++ {
 				// Run the Webhook, sending event and data along to the
 				//  Webhook's defined endpoint
-				err := w[j].Run(e[i], d, c.server.Id)
+				err := w[j].Run(e[i], d, c.server.ID)
 				if err != nil {
 					log.Println(WARNING, "webhooks:", fmt.Sprintf("%s:", e[i]), err)
 				}

--- a/pkg/server/socket/server.go
+++ b/pkg/server/socket/server.go
@@ -31,7 +31,7 @@ const (
 /*
 Server is the socket.io abstraction for Minimal Chat */
 type Server struct {
-	Id    string
+	ID    string
 	store *store.InMemory
 	sock  *socketio.Server
 


### PR DESCRIPTION
## Description
Since there may be situations where you will want to load the client on several domains, the need to support client requests to the daemon through dynamic domains we'll have to support this and the CORS if we want to keep things strict.

### Motivation
Mentioned in the descrpption

### Changes
- You can now give a comma delimited list of domains as a flag and when requests come in we'll check that list and return CORS headers if needed.


<!-- 
Feel free to add additional comments

Or Screenshots (bonus points for this!)
-->
